### PR TITLE
I added an exception for the '!' character in the cookie value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty</artifactId>
   <packaging>bundle</packaging>
-  <version>3.10.6.lendup</version>
+  <version>${project.version}</version>
 
   <name>Netty</name>
   <url>http://netty.io/</url>

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieEncoder.java
@@ -17,12 +17,19 @@ package org.jboss.netty.handler.codec.http.cookie;
 
 import static org.jboss.netty.handler.codec.http.cookie.CookieUtil.firstInvalidCookieNameOctet;
 import static org.jboss.netty.handler.codec.http.cookie.CookieUtil.firstInvalidCookieValueOctet;
+import static org.jboss.netty.handler.codec.http.cookie.CookieUtil.firstWarnCookieValueOctet;
 import static org.jboss.netty.handler.codec.http.cookie.CookieUtil.unwrapValue;
+
+import org.jboss.netty.logging.InternalLogger;
+import org.jboss.netty.logging.InternalLoggerFactory;
 
 /**
  * Parent of Client and Server side cookie encoders
  */
 public abstract class CookieEncoder {
+
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(CookieEncoder.class);
 
     private final boolean strict;
 
@@ -45,6 +52,11 @@ public abstract class CookieEncoder {
 
             if ((pos = firstInvalidCookieValueOctet(unwrappedValue)) >= 0) {
                 throw new IllegalArgumentException("Cookie value contains an invalid char: " + value.charAt(pos));
+            }
+
+            if ((pos = firstWarnCookieValueOctet(unwrappedValue)) >= 0) {
+                String warning = String.format("cookie with name '%s' has invalid characters", name);
+                logger.warn(warning);
             }
         }
     }

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieUtil.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieUtil.java
@@ -25,6 +25,8 @@ final class CookieUtil {
 
     private static final BitSet VALID_COOKIE_NAME_OCTETS = validCookieNameOctets(VALID_COOKIE_VALUE_OCTETS);
 
+    private static final BitSet WARN_COOKIE_OCTETS = warnCookieOctets();
+
     // US-ASCII characters excluding CTLs, whitespace, DQUOTE, comma, semicolon, and backslash
     private static BitSet validCookieValueOctets() {
         BitSet bits = new BitSet(8);
@@ -32,6 +34,7 @@ final class CookieUtil {
             // US-ASCII characters excluding CTLs (%x00-1F / %x7F)
             bits.set(i);
         }
+        bits.set('!', true); // include '!' because LDC needs it for now.
         bits.set('"', false);  // exclude DQUOTE = %x22
         bits.set(',', false);  // exclude comma = %x2C
         bits.set(';', false);  // exclude semicolon = %x3B
@@ -62,6 +65,12 @@ final class CookieUtil {
         bits.set('}', false);
         bits.set(' ', false);
         bits.set('\t', false);
+        return bits;
+    }
+
+    private static BitSet warnCookieOctets() {
+        BitSet bits = new BitSet(8);
+        bits.set('!', true);
         return bits;
     }
 
@@ -122,6 +131,10 @@ final class CookieUtil {
 
     static int firstInvalidCookieValueOctet(CharSequence cs) {
         return firstInvalidOctet(cs, VALID_COOKIE_VALUE_OCTETS);
+    }
+
+    static int firstWarnCookieValueOctet(CharSequence cs) {
+        return firstInvalidOctet(cs, WARN_COOKIE_OCTETS);
     }
 
     static int firstInvalidOctet(CharSequence cs, BitSet bits) {

--- a/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -80,4 +80,18 @@ public class ServerCookieEncoderTest {
         assertTrue(Math.abs(diff - maxAge) <= 2);
 
     }
+
+    @Test
+    public void lendupExclamationPointHack() {
+
+        String result =
+                "myCookie=my!Value";
+
+        Cookie cookie = new DefaultCookie("myCookie", "my!Value");
+
+        String encodedCookie = ServerCookieEncoder.STRICT.encode(cookie);
+
+        Matcher matcher = Pattern.compile(result).matcher(encodedCookie);
+        assertTrue(matcher.find());
+    }
 }


### PR DESCRIPTION
I added an exception for the '!' character in the cookie value
validation.  LDC is inserting '!' into cookies and I need to
whitelist that character.